### PR TITLE
fw/b lights: Allow black notification color

### DIFF
--- a/services/core/java/com/android/server/notification/NotificationRecord.java
+++ b/services/core/java/com/android/server/notification/NotificationRecord.java
@@ -218,6 +218,11 @@ public final class NotificationRecord {
                 if ((notification.defaults & Notification.DEFAULT_LIGHTS) != 0) {
                     light = new Light(defaultLightColor, defaultLightOn,
                             defaultLightOff);
+                } else if (light.color == 0) {
+                    // User has requested color 0.  However, lineage-sdk interprets
+                    // color 0 as "supply a default" therefore adjust alpha to make
+                    // the color still black but non-zero.
+                    light = new Light(0x01000000, light.onMs, light.offMs);
                 }
             } else {
                 light = null;


### PR DESCRIPTION
* Color 0 is used to mean "lineage-sdk should pick a default"

* Explictly requesting black made the led blue (eg lineageparts light picker), fix that

Change-Id: Ia03f898c1b6cd0f77af8bb155139b587664f47af